### PR TITLE
Add wysiwyg support

### DIFF
--- a/assets/css/cmb2-flexible.css
+++ b/assets/css/cmb2-flexible.css
@@ -1,6 +1,6 @@
-.cmb-type-flexible > .cmb-th, .cmb-type-flexible .cmb-th + .cmb-td {
-	float: none;
-	width: 100%;
+.cmb-type-flexible > .cmb-th, .cmb-type-flexible > .cmb-td {
+	float: none !important;
+	width: 100% !important;
 	max-width: 1000px;
 }
 

--- a/assets/js/cmb2-flexible.js
+++ b/assets/js/cmb2-flexible.js
@@ -49,7 +49,7 @@ var cmb_flexible = {};
 				// Initialize CMB at the end so that JS hooks work correctly.
 				cmb.newRowHousekeeping( newRow );
 				cmb.afterRowInsert( newRow );
-
+				window.CMB2.wysiwyg.initAll()
 			}
 		});
 	}

--- a/assets/js/cmb2-flexible.js
+++ b/assets/js/cmb2-flexible.js
@@ -30,6 +30,8 @@ var cmb_flexible = {};
 
 		$this.closest( '.cmb-flexible-add-list' ).addClass( 'hidden' );
 
+		$( flexible_group ).css( { opacity: 0.5 } );
+
 		$.ajax({
 			method: 'POST',
 			url: ajaxurl,
@@ -43,13 +45,24 @@ var cmb_flexible = {};
 			},
 
 			success: function( response ) {
+				$( flexible_group ).css( { opacity: 1 } );
 				var el = response.data;
 				var newRow = flexible_rows.append( el );
 
 				// Initialize CMB at the end so that JS hooks work correctly.
 				cmb.newRowHousekeeping( newRow );
 				cmb.afterRowInsert( newRow );
-				window.CMB2.wysiwyg.initAll()
+
+				$( newRow ).find( '.cmb2-wysiwyg-placeholder' ).each( function() {
+					$this = $( this );
+					data  = $this.data();
+
+					data.id    = $this.attr( 'id' );
+					data.name  = $this.attr( 'name' );
+					data.value = '';
+
+					cmb_flexible.initWysiwyg( $this, data );
+				});
 			}
 		});
 	}
@@ -70,6 +83,8 @@ var cmb_flexible = {};
 			var prevNum = $( this ).attr( 'data-groupindex' );
 			cmb_flexible.updateFlexibleNames( $next, prevNum );
 		} );
+
+		window.CMB2.wysiwyg.destroy( $parent.find( '.wp-editor-area' ).attr( 'id' ) );
 
 		$parent.remove();
 	}
@@ -101,6 +116,10 @@ var cmb_flexible = {};
 		var $goto     = 'up' === direction ? $from.prev( '.cmb-flexible-row' ) : $from.next( '.cmb-flexible-row' );
 		var gotoNum   = $goto.attr( 'data-groupindex' );
 
+		$from.find( '.wp-editor-wrap textarea' ).each( function() {
+			window.CMB2.wysiwyg.destroy( $( this ).attr( 'id' ) );
+		} );
+
 
 		if ( 'up' === direction && 0 === parseInt( fromNum ) ) {
 			return false;
@@ -116,7 +135,54 @@ var cmb_flexible = {};
 
 		cmb_flexible.updateFlexibleNames( $from, fromNum, gotoNum );
 		cmb_flexible.updateFlexibleNames( $goto, gotoNum, fromNum );
+
+		$from.each( function() {
+			cmb_flexible.setWysiwygRow( $( this ) );
+		} );
 	}
+
+	cmb_flexible.setWysiwygRow = function( $el ) {
+		var wysiwyg = $el.find( '.wp-editor-wrap textarea' );
+		var wysiwyg_id = wysiwyg.attr( 'id' );
+
+		if ( tinyMCEPreInit.mceInit[ wysiwyg_id ] ) {
+			window.CMB2.wysiwyg.initRow( $el );
+		} else {
+			var $toReplace = wysiwyg.closest( '.cmb2-wysiwyg-inner-wrap' );
+			data          = $toReplace.data();
+			data.fieldid  = data.id;
+			data.id       = data.groupid + '_' + data.iterator + '_' + data.fieldid;
+			data.name     = data.groupid + '[' + data.iterator + '][' + data.fieldid + ']';
+			data.value    = $toReplace.find( '.wp-editor-area' ).length ? $toReplace.find( '.wp-editor-area' ).val() : '';
+
+			cmb_flexible.initWysiwyg( $toReplace, data );
+		}
+	}
+
+	cmb_flexible.initWysiwyg = function( $toReplace, data ) {
+		var mceData = tinyMCEPreInit.mceInit.content;
+		mceData.selector = '#' + data.id;
+
+		var qtData = tinyMCEPreInit.qtInit.content;
+		qtData.id = data.id;
+		$.extend( data, {
+			template: wp.template( 'cmb2-wysiwyg-' + data.groupid + '-' + data.fieldid ),
+			defaults: {
+				mce: mceData,
+				qt: qtData,
+			}
+		} );
+
+		$toReplace.replaceWith( data.template( data ) );
+		window.tinyMCE.init( mceData );
+
+		if ( 'function' === typeof window.quicktags ) {
+			window.quicktags( qtData );
+		}
+
+		$( document.getElementById( data.id ) ).parents( '.wp-editor-wrap' ).removeClass( 'html-active' ).addClass( 'tmce-active' );
+	}
+
 
 	$( cmb_flexible.init );
 })( jQuery, window.CMB2 );

--- a/assets/js/cmb2-flexible.js
+++ b/assets/js/cmb2-flexible.js
@@ -10,7 +10,7 @@ var cmb_flexible = {};
 			.on( 'click', '.cmb-flexible-add-button', cmb_flexible.removeFlexibleHiddenClass )
 			.on( 'click', '.cmb-remove-flexible-row', cmb_flexible.removeFlexibleRow )
 			.on( 'click', '.cmb-shift-flexible-rows', cmb_flexible.shiftRows );
-	}
+	};
 
 	cmb_flexible.addFlexibleRow = function( evt ) {
 		evt.preventDefault();
@@ -65,12 +65,12 @@ var cmb_flexible = {};
 				});
 			}
 		});
-	}
+	};
 
 	cmb_flexible.removeFlexibleHiddenClass = function( evt ) {
 		evt.preventDefault();
 		var list = $( this ).next( '.cmb-flexible-add-list' ).removeClass( 'hidden' );
-	}
+	};
 
 	cmb_flexible.removeFlexibleRow = function( evt ) {
 		evt.preventDefault();
@@ -87,7 +87,7 @@ var cmb_flexible = {};
 		window.CMB2.wysiwyg.destroy( $parent.find( '.wp-editor-area' ).attr( 'id' ) );
 
 		$parent.remove();
-	}
+	};
 
 	cmb_flexible.updateFlexibleNames = function( $el, prevNum, newNum ) {
 		if ( $el.length > 0 ) {
@@ -104,7 +104,7 @@ var cmb_flexible = {};
 				}
 			} );
 		}
-	}
+	};
 
 	cmb_flexible.shiftRows = function( evt ) {
 		evt.preventDefault();
@@ -139,7 +139,7 @@ var cmb_flexible = {};
 		$from.each( function() {
 			cmb_flexible.setWysiwygRow( $( this ) );
 		} );
-	}
+	};
 
 	cmb_flexible.setWysiwygRow = function( $el ) {
 		var wysiwyg = $el.find( '.wp-editor-wrap textarea' );
@@ -163,7 +163,7 @@ var cmb_flexible = {};
 
 		}
 
-	}
+	};
 
 	cmb_flexible.initWysiwyg = function( $toReplace, data ) {
 		var mceData = tinyMCEPreInit.mceInit.content;
@@ -187,7 +187,7 @@ var cmb_flexible = {};
 		}
 
 		$( document.getElementById( data.id ) ).parents( '.wp-editor-wrap' ).removeClass( 'html-active' ).addClass( 'tmce-active' );
-	}
+	};
 
 
 	$( cmb_flexible.init );

--- a/assets/js/cmb2-flexible.js
+++ b/assets/js/cmb2-flexible.js
@@ -143,20 +143,26 @@ var cmb_flexible = {};
 
 	cmb_flexible.setWysiwygRow = function( $el ) {
 		var wysiwyg = $el.find( '.wp-editor-wrap textarea' );
-		var wysiwyg_id = wysiwyg.attr( 'id' );
 
-		if ( tinyMCEPreInit.mceInit[ wysiwyg_id ] ) {
-			window.CMB2.wysiwyg.initRow( $el );
-		} else {
-			var $toReplace = wysiwyg.closest( '.cmb2-wysiwyg-inner-wrap' );
-			data          = $toReplace.data();
-			data.fieldid  = data.id;
-			data.id       = data.groupid + '_' + data.iterator + '_' + data.fieldid;
-			data.name     = data.groupid + '[' + data.iterator + '][' + data.fieldid + ']';
-			data.value    = $toReplace.find( '.wp-editor-area' ).length ? $toReplace.find( '.wp-editor-area' ).val() : '';
+		if ( wysiwyg.length > 0 ) {
 
-			cmb_flexible.initWysiwyg( $toReplace, data );
+			var wysiwyg_id = wysiwyg.attr( 'id' );
+
+			if ( tinyMCEPreInit.mceInit[ wysiwyg_id ] ) {
+				window.CMB2.wysiwyg.initRow( $el );
+			} else {
+				var $toReplace = wysiwyg.closest( '.cmb2-wysiwyg-inner-wrap' );
+				data          = $toReplace.data();
+				data.fieldid  = data.id;
+				data.id       = data.groupid + '_' + data.iterator + '_' + data.fieldid;
+				data.name     = data.groupid + '[' + data.iterator + '][' + data.fieldid + ']';
+				data.value    = $toReplace.find( '.wp-editor-area' ).length ? $toReplace.find( '.wp-editor-area' ).val() : '';
+
+				cmb_flexible.initWysiwyg( $toReplace, data );
+			}
+
 		}
+
 	}
 
 	cmb_flexible.initWysiwyg = function( $toReplace, data ) {

--- a/cmb2-flexible-content-field.php
+++ b/cmb2-flexible-content-field.php
@@ -32,6 +32,8 @@ if ( ! class_exists( 'RKV_CMB2_Flexible_Content_Field', false ) ) {
 		 */
 		protected $stored_data;
 
+		protected $wysiwygs = array();
+
 		/**
 		 * Set up static instance of class
 		 *
@@ -353,6 +355,21 @@ if ( ! class_exists( 'RKV_CMB2_Flexible_Content_Field', false ) ) {
 			echo '</div>';
 
 			echo '</div>';
+
+			if ( false === $override && ! empty( $this->wysiwygs ) ) {
+				foreach ( $this->wysiwygs as $wysiwyg ) {
+					// $types = new CMB2_Types( $wysiwyg );
+					// $wysiwyg_type = $types->get_new_render_type( 'wysiwyg', 'CMB2_Type_Wysiwyg', $subfield_args );
+					//error_log( print_r( $wysiwyg, true ));
+
+					//$wysiwyg->add_wysiwyg_template_for_group();
+					$wysiwyg['group']->index = 0;
+					$wysiwyg_field = $metabox->get_field( $wysiwyg['args'], $wysiwyg['group'] );
+					$types = new CMB2_Types( $wysiwyg_field );
+					$wysiwyg_type = $types->get_new_render_type( 'wysiwyg', 'CMB2_Type_Wysiwyg', $wysiwyg['args'] );
+					$wysiwyg_type->add_wysiwyg_template_for_group();
+				}
+			}
 		}
 
 		/**
@@ -395,16 +412,18 @@ if ( ! class_exists( 'RKV_CMB2_Flexible_Content_Field', false ) ) {
 				$subfield_args['array_key'] = absint( $index );
 				$subfield_id = $metabox->add_group_field( $group_name, $subfield_args );
 
-				// if ( 'wysiwyg' === $subfield_args['type'] ) {
+				if ( 'wysiwyg' === $subfield_args['type'] ) {
 
-				// 	$group = $metabox->get_field( $group_name );
-				// 	$wysiwyg = $metabox->get_field( $subfield_args, $group );
-				// 	$types = new CMB2_Types( $wysiwyg );
+					$group = $metabox->get_field( $group_name );
+					$this->wysiwygs[] = array(
+						'group' => $group,
+						'args' => $subfield_args,
+					);
+					// $wysiwyg = $metabox->get_field( $subfield_args, $group );
+					// $types = new CMB2_Types( $wysiwyg );
+					// $this->wysiwygs[] = $types->get_new_render_type( 'wysiwyg', 'CMB2_Type_Wysiwyg', $subfield_args );
 
-
-				// 	$this->wysiwyg = $types->get_new_render_type( 'wysiwyg', 'CMB2_Type_Wysiwyg', $subfield_args );
-
-				// }
+				}
 			}
 
 			// Set some necessary defaults.

--- a/cmb2-flexible-content-field.php
+++ b/cmb2-flexible-content-field.php
@@ -354,22 +354,18 @@ if ( ! class_exists( 'RKV_CMB2_Flexible_Content_Field', false ) ) {
 			echo '<button class="button cmb-shift-flexible-rows move-down alignleft dashicons-before dashicons-arrow-down-alt2"></button>';
 			echo '</div>';
 
-			echo '</div>';
-
 			if ( false === $override && ! empty( $this->wysiwygs ) ) {
-				foreach ( $this->wysiwygs as $wysiwyg ) {
-					// $types = new CMB2_Types( $wysiwyg );
-					// $wysiwyg_type = $types->get_new_render_type( 'wysiwyg', 'CMB2_Type_Wysiwyg', $subfield_args );
-					//error_log( print_r( $wysiwyg, true ));
-
-					//$wysiwyg->add_wysiwyg_template_for_group();
-					$wysiwyg['group']->index = 0;
-					$wysiwyg_field = $metabox->get_field( $wysiwyg['args'], $wysiwyg['group'] );
+				foreach ( $this->wysiwygs as $wysiwyg_id => $field_group ) {
+					$field_group->index = 0;
+					$wysiwyg_field = $metabox->get_field( $wysiwyg_id, $field_group );
 					$types = new CMB2_Types( $wysiwyg_field );
-					$wysiwyg_type = $types->get_new_render_type( 'wysiwyg', 'CMB2_Type_Wysiwyg', $wysiwyg['args'] );
+					$wysiwyg_type = $types->get_new_render_type( 'wysiwyg', 'CMB2_Type_Wysiwyg', array() );
 					$wysiwyg_type->add_wysiwyg_template_for_group();
 				}
 			}
+
+			echo '</div>';
+
 		}
 
 		/**
@@ -413,16 +409,8 @@ if ( ! class_exists( 'RKV_CMB2_Flexible_Content_Field', false ) ) {
 				$subfield_id = $metabox->add_group_field( $group_name, $subfield_args );
 
 				if ( 'wysiwyg' === $subfield_args['type'] ) {
-
 					$group = $metabox->get_field( $group_name );
-					$this->wysiwygs[] = array(
-						'group' => $group,
-						'args' => $subfield_args,
-					);
-					// $wysiwyg = $metabox->get_field( $subfield_args, $group );
-					// $types = new CMB2_Types( $wysiwyg );
-					// $this->wysiwygs[] = $types->get_new_render_type( 'wysiwyg', 'CMB2_Type_Wysiwyg', $subfield_args );
-
+					$this->wysiwygs[ $subfield_args['id'] ] = $group;
 				}
 			}
 

--- a/cmb2-flexible-content-field.php
+++ b/cmb2-flexible-content-field.php
@@ -32,6 +32,11 @@ if ( ! class_exists( 'RKV_CMB2_Flexible_Content_Field', false ) ) {
 		 */
 		protected $stored_data;
 
+		/**
+		 * Holds an array of wysiwyg fields so templates can be output
+		 *
+		 * @var array
+		 */
 		protected $wysiwygs = array();
 
 		/**
@@ -275,7 +280,6 @@ if ( ! class_exists( 'RKV_CMB2_Flexible_Content_Field', false ) ) {
 				$saved[ $i ] = CMB2_Utils::filter_empty( $saved[ $i ] );
 			}
 			$saved = CMB2_Utils::filter_empty( $saved );
-
 
 			return $saved;
 		}


### PR DESCRIPTION
Ok, this adds WYSIWYG support in a basic way.

It uses the global defaults of the content field to initiate tinyMCE instead of a custom setup, but it gets us a good amount of the way there.

In order for it to work generally, each group that's created is given a separate name, then a hidden field is added to capture that name and piece it all together during sanitization.

Also cleans up some styles.