### PR TITLE
Adding back in group cloning for fields with titles

### DIFF
--- a/cmb2-flexible-content-field.php
+++ b/cmb2-flexible-content-field.php
@@ -390,7 +390,7 @@ if ( ! class_exists( 'RKV_CMB2_Flexible_Content_Field', false ) ) {
 				$group_args['options'] = array(
 					'group_title' => $layout['title'],
 				);
-				$field->set_prop( 'options', $group_args['options'] );
+				$field = $field->get_field_clone( $group_args );
 			}
 
 			$metabox->add_field( $group_args );


### PR DESCRIPTION
There was an issue with the "Remove Group" and group titles when fields are not re-cloned. This can be addressed in #9, but for now it's best to leave it in.